### PR TITLE
fixed include for case-sensitive OS.

### DIFF
--- a/max6675.cpp
+++ b/max6675.cpp
@@ -4,7 +4,7 @@
 #include <avr/pgmspace.h>
 #include <util/delay.h>
 #include <stdlib.h>
-#include "MAX6675.h"
+#include "max6675.h"
 
 MAX6675::MAX6675(int8_t SCLK, int8_t CS, int8_t MISO) {
   sclk = SCLK;


### PR DESCRIPTION
"MAX6675.h file not found" errors during compilation using Arduino 1.0 on Ubuntu were caused by #include "MAX6675.h" rather than "max6675.h"

Thanks for the library.

Merry Christmas.
