### PR TITLE
fixed missing file errors when compiling for esp8266

### DIFF
--- a/max6675.cpp
+++ b/max6675.cpp
@@ -1,5 +1,5 @@
 // this library is public domain. enjoy!
-// www.ladyada.net/learn/sensors/thermocouple
+// https://learn.adafruit.com/thermocouple/using-a-thermocouple
 
 #ifdef __AVR
   #include <avr/pgmspace.h>

--- a/max6675.cpp
+++ b/max6675.cpp
@@ -1,10 +1,16 @@
 // this library is public domain. enjoy!
 // www.ladyada.net/learn/sensors/thermocouple
 
-#include <avr/pgmspace.h>
-#include <util/delay.h>
+#ifdef __AVR
+  #include <avr/pgmspace.h>
+#elif defined(ESP8266)
+  #include <pgmspace.h>
+#endif
+
 #include <stdlib.h>
-#include "MAX6675.h"
+#include "max6675.h"
+
+#define _delay_ms(ms) delayMicroseconds((ms) * 1000)
 
 MAX6675::MAX6675(int8_t SCLK, int8_t CS, int8_t MISO) {
   sclk = SCLK;


### PR DESCRIPTION
When compiling max6675 library files for esp8266, avr/pgmspace.h was missing and then util/delay.h
