### PR TITLE
Replaced AVR-specific _delay_ms() with general routine

### DIFF
--- a/max6675.cpp
+++ b/max6675.cpp
@@ -6,7 +6,6 @@
 #elif defined(ESP8266)
   #include <pgmspace.h>
 #endif
-#include <util/delay.h>
 #include <stdlib.h>
 #include "max6675.h"
 
@@ -27,7 +26,7 @@ double MAX6675::readCelsius(void) {
   uint16_t v;
 
   digitalWrite(cs, LOW);
-  _delay_ms(1);
+  delay(1);
 
   v = spiread();
   v <<= 8;
@@ -57,14 +56,14 @@ byte MAX6675::spiread(void) {
   for (i=7; i>=0; i--)
   {
     digitalWrite(sclk, LOW);
-    _delay_ms(1);
+    delay(1);
     if (digitalRead(miso)) {
       //set the bit to 0 no matter what
       d |= (1 << i);
     }
 
     digitalWrite(sclk, HIGH);
-    _delay_ms(1);
+    delay(1);
   }
 
   return d;


### PR DESCRIPTION
Code does not compile on Arduino Due and other non-AVR devices. Replaced _delay_ms() which is AVR-specific to Arduino general delay().
