### PR TITLE
change implicit conversions to floats

### DIFF
--- a/max6675.cpp
+++ b/max6675.cpp
@@ -60,7 +60,7 @@ float MAX6675::readCelsius(void) {
     @returns Temperature in F or NAN on failure!
 */
 /**************************************************************************/
-float MAX6675::readFahrenheit(void) { return readCelsius() * 9.0 / 5.0 + 32; }
+float MAX6675::readFahrenheit(void) { return readCelsius() * 9.0f / 5.0f + 32.0f; }
 
 byte MAX6675::spiread(void) {
   int i;


### PR DESCRIPTION
The scope of the change is limited to the MAX6675::readFahrenheit function and removes the implicit conversion to a double and than the implicit conversion back to float. I can't see any benefit in needing the extra precision here and the result will likely be lost from the return value.

This change fixes the compiler warnings that are produced from this function and will avoid double arithmetic which is often less performant on embedded systems. 

```
...\MAX6675 library\max6675.cpp: In member function 'float MAX6675::readFahrenheit()':
...\MAX6675 library\max6675.cpp:63:60: warning: implicit conversion from 'float' to 'double' to match other operand of binary expression [-Wdouble-promotion]
   63 | float MAX6675::readFahrenheit(void) { return readCelsius() * 9.0 / 5.0 + 32; }
```